### PR TITLE
Fqaのcss調節

### DIFF
--- a/src/components/MenuListComponent.vue
+++ b/src/components/MenuListComponent.vue
@@ -29,7 +29,7 @@ export default {
   width: 9rem;
   font-size: 1.5rem;
   text-align: center;
-  @media (max-width: 450px) {
+  @media (max-width: 480px) {
     width: 6rem;
     font-size: 1rem;
   }

--- a/src/datas/QAData.js
+++ b/src/datas/QAData.js
@@ -2,7 +2,7 @@ export class QAData{
     constructor() {
         this.list =[
             {
-                tag:["技術","興味"],
+                tag:["技術","興味/関心"],
                 Q:"興味がある､今後触ってみたい技術や分野は?",
                 A: `
 * nginx
@@ -33,7 +33,7 @@ export class QAData{
                 `
             },
             {
-                tag:["技術","興味"],
+                tag:["技術","興味/関心"],
                 Q:"今後作ってみたいもの,技術的にやってみたいことは?",
                 A:`
 * (達成)~~laravelとvueを組み合わせたwebサービス~~
@@ -51,7 +51,7 @@ export class QAData{
                 `
             },
             {
-                tag:["興味"],
+                tag:["興味/関心"],
                 Q:"技術以外にやってみたいことなどは?",
                 A:`
 * ハックバーに行ってみたい

--- a/src/views/FQA.vue
+++ b/src/views/FQA.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <div class="tags">
-      <template v-for="(label, index) of labels">
+      <template v-for="label of labels">
         <button
-          :key="index"
+          :key="label"
           @click="
             filter(label);
             setNowShowing(label);

--- a/src/views/FQA.vue
+++ b/src/views/FQA.vue
@@ -1,25 +1,20 @@
 <template>
   <div>
-    <v-row>
-      <v-btn-toggle
-        color="deep-purple accent-3"
-        class="tags"
-        v-model="toggle_exclusive"
-        mandatory
-      >
-        <v-btn value="すべて" class="v-btn" @click="filter(null)">すべて</v-btn>
-        <v-btn value="技術" class="v-btn" @click="filter('技術')">技術</v-btn>
-        <v-btn value="興味" class="v-btn" @click="filter('興味')"
-          >興味/関心</v-btn
+    <div class="tags">
+      <template v-for="(label, index) of labels">
+        <button
+          :key="index"
+          @click="
+            filter(label);
+            setNowShowing(label);
+          "
+          :class="{ active: nowShowing == label }"
+          :disabled="nowShowing == label"
         >
-        <v-btn value="性格" class="v-btn" @click="filter('性格')">性格</v-btn>
-        <v-btn value="考え" class="v-btn" @click="filter('考え')">考え</v-btn>
-        <v-btn value="過去" class="v-btn" @click="filter('過去')">過去</v-btn>
-        <v-btn value="その他" class="v-btn" @click="filter('その他')"
-          >その他</v-btn
-        >
-      </v-btn-toggle>
-    </v-row>
+          {{ label }}
+        </button>
+      </template>
+    </div>
 
     <div v-for="element of QAList" :key="element.Q">
       <q-a-component :data="element"> </q-a-component>
@@ -37,17 +32,17 @@ export default {
   },
   data() {
     return {
+      labels: ["すべて", "技術", "興味/関心", "性格", "過去", "その他"],
       QA: new QAData(),
       QAList: null,
-      //トグル管理
-      toggle_exclusive: undefined,
+      nowShowing: "すべて",
     };
   },
   methods: {
     filter(arg = null) {
       // 引数が空の時
       // すべて表示する
-      if (arg == null) {
+      if (arg == "すべて") {
         return (this.QAList = this.QA.list);
       }
 
@@ -60,27 +55,43 @@ export default {
       }
       return (this.QAList = List);
     },
+    setNowShowing(arg) {
+      this.nowShowing = arg;
+    },
   },
   mounted() {
-    this.filter(null);
+    this.filter("すべて");
   },
 };
 </script>
 
 <style lang="scss">
 .tags {
+  display: flex;
   flex-wrap: wrap;
-  margin: 1rem auto;
+  margin: 1rem 0;
+  width: 100%;
   button {
-    width: 10rem;
-    @media (max-width: 450px) {
-      width: 25vw;
+    font-size: 1.2rem;
+    background-color: #ebeef0;
+    color: #000000;
+    border: 1px solid black;
+    @media (min-width: 451px) {
+      flex: 1;
+      min-width: 0;
+      box-sizing: border-box;
     }
+    @media (max-width: 450px) {
+      width: 25%;
+    }
+  }
+  .active {
+    background-color: #112d4e;
+    color: #f9f7f7;
+    font-weight: bold;
   }
 }
 .QA {
   margin: 0.5rem 0;
 }
 </style>
-<!-- align="center"
-justify="center" -->

--- a/src/views/FQA.vue
+++ b/src/views/FQA.vue
@@ -76,12 +76,12 @@ export default {
     background-color: #ebeef0;
     color: #000000;
     border: 1px solid black;
-    @media (min-width: 451px) {
+    @media (min-width: 481px) {
       flex: 1;
       min-width: 0;
       box-sizing: border-box;
     }
-    @media (max-width: 450px) {
+    @media (max-width: 480px) {
       width: 25%;
     }
   }

--- a/src/views/MyWorks/MyWorks.vue
+++ b/src/views/MyWorks/MyWorks.vue
@@ -70,7 +70,7 @@ export default {
 <style lang="scss" scoped>
 .workCard {
   width: 49%;
-  @media (max-width: 450px) {
+  @media (max-width: 480px) {
     width: 100%;
   }
 }
@@ -79,7 +79,7 @@ export default {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
-  @media (max-width: 450px) {
+  @media (max-width: 480px) {
     gap: 2rem;
   }
 }
@@ -100,7 +100,7 @@ export default {
     width: 8rem;
     font-size: 1.2rem;
     text-align: center;
-    @media (max-width: 450px) {
+    @media (max-width: 480px) {
       width: 6rem;
       font-size: 1rem;
     }

--- a/src/views/MyWorks/MyWorks.vue
+++ b/src/views/MyWorks/MyWorks.vue
@@ -49,7 +49,7 @@ export default {
       // dataは安直すぎた?
       originalWorks: new OriginalWorks(),
       sampleWorks: new SampleWorks(),
-      data: new OriginalWorks(), // この中ではすぐにthis.originalWorksとしていできない｡mountedでいれるのも面倒
+      data: null,
       nowShowing: "original",
     };
   },
@@ -60,6 +60,9 @@ export default {
     setNowShowing(arg) {
       this.nowShowing = arg;
     },
+  },
+  mounted() {
+    this.data = this.originalWorks;
   },
 };
 </script>


### PR DESCRIPTION
もともと､謎の余白があったのでそれがどうしても気になるので消えるように色々書き換えた｡

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 質問のタグを「興味」から「興味/関心」に更新して、より広範なカテゴリー分類を反映しました。
	- FQA(よくある質問)ビューにおいて、静的なボタン切り替えから動的なボタンリストへの変更を行い、異なるカテゴリーに基づいて質問をフィルタリングできるようにしました。また、タグボタンのスタイリングを強化し、視覚的なプレゼンテーションを向上させました。

- **バグ修正**
	- `MyWorks.vue`において、`data`プロパティを`new OriginalWorks()`ではなく`null`で初期化し、`mounted`フックで`this.originalWorks`に設定するように変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->